### PR TITLE
chore: update rust_sdk

### DIFF
--- a/contract-rs/Cargo.toml
+++ b/contract-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contract-rs"
-description = "cargo-near-new-project-description"
+description = "Hello Near Example"
 version = "0.1.0"
 edition = "2021"
 # TODO: Fill out the repository field to help NEAR ecosystem tools to discover your project.
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-near-sdk = "5.0.0"
+near-sdk = "5.1.0"
 
 [dev-dependencies]
 near-sdk = { version = "5.0.0", features = ["unit-testing"] }

--- a/contract-rs/src/lib.rs
+++ b/contract-rs/src/lib.rs
@@ -1,11 +1,8 @@
 // Find all our documentation at https://docs.near.org
-use near_sdk::borsh::{BorshDeserialize, BorshSerialize};
-use near_sdk::{log, near_bindgen};
+use near_sdk::{log, near};
 
 // Define the contract structure
-#[near_bindgen]
-#[derive(BorshDeserialize, BorshSerialize)]
-#[borsh(crate = "near_sdk::borsh")]
+#[near(contract_state)]
 pub struct Contract {
     greeting: String,
 }
@@ -20,7 +17,7 @@ impl Default for Contract {
 }
 
 // Implement the contract structure
-#[near_bindgen]
+#[near]
 impl Contract {
     // Public method - returns the greeting saved, defaulting to DEFAULT_GREETING
     pub fn get_greeting(&self) -> String {


### PR DESCRIPTION
Update rust sdk to 5.1 making use of #[near] and #[near(contract_state)]