### PR TITLE
fix: greeting

### DIFF
--- a/contract-rs/src/lib.rs
+++ b/contract-rs/src/lib.rs
@@ -11,7 +11,7 @@ pub struct Contract {
 impl Default for Contract {
     fn default() -> Self {
         Self {
-            greeting: "Hello".to_string(),
+            greeting: "Howdy".to_string(),
         }
     }
 }


### PR DESCRIPTION
Hello, I noticed that you had the wrong greeting, it was supposed to say "Howdy" instead of "Hello" because we prefer to use an accent 