### PR TITLE
Migrate Wagmi to Use Reown Library  

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,19 +30,12 @@
     "@near-wallet-selector/welldone-wallet": "^8.10.0",
     "@reown/appkit": "^1.6.9",
     "@reown/appkit-adapter-wagmi": "^1.6.9",
-    "@web3modal/wagmi": "^5.1.11",
     "bootstrap": "^5",
     "bootstrap-icons": "^1.11.3",
     "near-api-js": "^5.0.1",
-    "next": "15.0.3",
+    "next": "15.2.1",
     "react": "^18",
-    "react-dom": "^18",
-    "wagmi": "^2.13.3"
-  },
-  "overrides": {
-    "@near-wallet-selector/ethereum-wallets": {
-      "near-api-js": "4.0.3"
-    }
+    "react-dom": "^18"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,8 @@
     "@near-wallet-selector/react-hook": "^8.9.15",
     "@near-wallet-selector/sender": "^8.10.0",
     "@near-wallet-selector/welldone-wallet": "^8.10.0",
+    "@reown/appkit": "^1.6.9",
+    "@reown/appkit-adapter-wagmi": "^1.6.9",
     "@web3modal/wagmi": "^5.1.11",
     "bootstrap": "^5",
     "bootstrap-icons": "^1.11.3",

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -17,13 +17,13 @@ import { HelloNearContract, NetworkId } from '@/config';
 import { Navigation } from '@/components/navigation';
 
 // ethereum wallets
-import { wagmiConfig, web3Modal } from '@/wallets/web3modal';
+import { wagmiAdapter, web3Modal } from '@/wallets/web3modal';
 
 const walletSelectorConfig = {
   network: NetworkId,
   // createAccessKeyFor: HelloNearContract,
   modules: [
-    setupEthereumWallets({ wagmiConfig, web3Modal, alwaysOnboardDuringSignIn: true }),
+    setupEthereumWallets({ wagmiConfig: wagmiAdapter.wagmiConfig, web3Modal }),
     setupBitteWallet(),
     setupMeteorWallet(),
     setupMeteorWalletApp({contractId: HelloNearContract}),

--- a/frontend/src/wallets/web3modal.js
+++ b/frontend/src/wallets/web3modal.js
@@ -1,42 +1,45 @@
-import { injected,walletConnect } from '@wagmi/connectors';
-import { createConfig,http, reconnect } from '@wagmi/core';
-import { createWeb3Modal } from '@web3modal/wagmi';
-
-import { EVMWalletChain,NetworkId } from '@/config';
-
-// Config
-const near = {
-  id: EVMWalletChain.chainId,
-  name: EVMWalletChain.name,
-  nativeCurrency: {
-    decimals: 18,
-    name: 'NEAR',
-    symbol: 'NEAR',
-  },
-  rpcUrls: {
-    default: { http: [EVMWalletChain.rpc] },
-    public: { http: [EVMWalletChain.rpc] },
-  },
-  blockExplorers: {
-    default: {
-      name: 'NEAR Explorer',
-      url: EVMWalletChain.explorer,
-    },
-  },
-  testnet: NetworkId === 'testnet',
-};
+import { createAppKit } from "@reown/appkit/react";
+import { reconnect } from "@wagmi/core";
+import { injected, walletConnect } from "@wagmi/connectors";
+import { nearTestnet } from "@reown/appkit/networks";
+import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 
 // Get your projectId at https://cloud.reown.com
 const projectId = '5bb0fe33763b3bea40b8d69e4269b4ae';
+const connectors = [
+  walletConnect({
+    projectId,
+    metadata: {
+      name: "Hello near examples",
+      description: "Examples demonstrating integrations with NEAR blockchain",
+      url: "https://near.github.io/wallet-selector",
+      icons: ["https://near.github.io/wallet-selector/favicon.ico"],
+    },
+    showQrModal: false, // showQrModal must be false
+  }),
+  injected({ shimDisconnect: true }),
+];
 
-export const wagmiConfig = createConfig({
-  chains: [near],
-  transports: { [near.id]: http() },
-  connectors: [walletConnect({ projectId, showQrModal: false }), injected({ shimDisconnect: true })],
+export const wagmiAdapter = new WagmiAdapter({
+  projectId,
+  connectors,
+  networks: [nearTestnet],
 });
 
-// Preserve login state on page reload
-reconnect(wagmiConfig);
+reconnect(wagmiAdapter.wagmiConfig);
 
-// Modal for login
-export const web3Modal = createWeb3Modal({ wagmiConfig, projectId });
+export const web3Modal = createAppKit({
+  adapters: [wagmiAdapter],
+  projectId,
+  networks: [nearTestnet],
+  defaultNetwork: nearTestnet,
+  enableWalletConnect: true,
+  features: {
+    analytics: true,
+    swaps: false,
+    onramp: false,
+    email: false, // Smart accounts (Safe contract) not available on NEAR Protocol, only EOA.
+    socials: false, // Smart accounts (Safe contract) not available on NEAR Protocol, only EOA.
+  },
+  coinbasePreference: "eoaOnly", // Smart accounts (Safe contract) not available on NEAR Protocol, only EOA.
+});


### PR DESCRIPTION
**Description:**  

This PR updates the Wagmi integration to use the new **reown** library instead of the previous implementation.