### PR TITLE
fix test_greeting() failing test_greeting.py

### DIFF
--- a/contract-py/tests/test_greeting.py
+++ b/contract-py/tests/test_greeting.py
@@ -41,7 +41,7 @@ class TestGreetingContract(NearTestCase):
             method_name="set_greeting",
             args={"message": "Hello from test!"}
         )
-        result = json.loads(result)
+        result = json.loads(result.text)
         assert result["success"] == True
         
         # Get greeting
@@ -49,5 +49,5 @@ class TestGreetingContract(NearTestCase):
             account=self.user,
             method_name="get_greeting"
         )
-        assert greeting == "Hello from test!"
+        assert greeting.text == "Hello from test!"
         


### PR DESCRIPTION
## Merge Request: Fix ContractResponse Handling

### Problem Description
The current code is failing tests due to incorrect handling of `ContractResponse` objects:
- TypeError when attempting to use `json.loads()` directly on a `ContractResponse`
- Assertion failures when comparing `ContractResponse` to expected string values

### Proposed Changes
```diff
- result = json.loads(result)
+ result = json.loads(result.text)
```
```diff
- assert greeting == "Hello from test!"
+ assert greeting.text == "Hello from test!"
```

### Explanation

- Use `.text` property to convert `ContractResponse` to a string before parsing
- When making assertions, access the `.text` attribute of the `ContractResponse`

### Test Modifications
Ensure that JSON parsing and assertions use the `.text` attribute of the `ContractResponse` object to extract the string value.